### PR TITLE
Fix code scanning alert no. 1: Prototype-polluting assignment

### DIFF
--- a/7-bank-project/api/server.js
+++ b/7-bank-project/api/server.js
@@ -94,7 +94,11 @@ router.get('/accounts/:user', (req, res) => {
 
 // Remove specified account
 router.delete('/accounts/:user', (req, res) => {
-  const account = db[req.params.user];
+  const user = req.params.user;
+  if (user === '__proto__' || user === 'constructor' || user === 'prototype') {
+    return res.status(400).json({ error: 'Invalid user' });
+  }
+  const account = db[user];
 
   // Check if account exists
   if (!account) {
@@ -102,7 +106,7 @@ router.delete('/accounts/:user', (req, res) => {
   }
 
   // Removed account
-  delete db[req.params.user];
+  delete db[user];
 
   res.sendStatus(204);
 });
@@ -111,7 +115,11 @@ router.delete('/accounts/:user', (req, res) => {
 
 // Add a transaction to a specific account
 router.post('/accounts/:user/transactions', (req, res) => {
-  const account = db[req.params.user];
+  const user = req.params.user;
+  if (user === '__proto__' || user === 'constructor' || user === 'prototype') {
+    return res.status(400).json({ error: 'Invalid user' });
+  }
+  const account = db[user];
 
   // Check if account exists
   if (!account) {
@@ -164,7 +172,11 @@ router.post('/accounts/:user/transactions', (req, res) => {
 
 // Remove specified transaction from account
 router.delete('/accounts/:user/transactions/:id', (req, res) => {
-  const account = db[req.params.user];
+  const user = req.params.user;
+  if (user === '__proto__' || user === 'constructor' || user === 'prototype') {
+    return res.status(400).json({ error: 'Invalid user' });
+  }
+  const account = db[user];
 
   // Check if account exists
   if (!account) {


### PR DESCRIPTION
Fixes [https://github.com/Dargon789/Web-Dev-For-Beginners/security/code-scanning/1](https://github.com/Dargon789/Web-Dev-For-Beginners/security/code-scanning/1)

To fix the prototype pollution vulnerability, we need to ensure that user-controlled input cannot be used to modify `Object.prototype`. This can be achieved by validating the `req.params.user` value to ensure it does not contain special property names like `__proto__`, `constructor`, or `prototype`.

The best way to fix this without changing existing functionality is to add a validation check before accessing the `db` object. If the `req.params.user` value is one of the special property names, we should return an error response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
