### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/azure-static-web-apps-ashy-river-0debb7803.yml
+++ b/.github/workflows/azure-static-web-apps-ashy-river-0debb7803.yml
@@ -1,7 +1,10 @@
 name: Azure Static Web Apps CI/CD
 
-on: workflow_dispatch
+permissions:
+  contents: read
+  pull-requests: write
 
+on: workflow_dispatch
 jobs:
   build_and_deploy_job:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/Web-Dev-For-Beginners/security/code-scanning/4](https://github.com/Dargon789/Web-Dev-For-Beginners/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root level of the workflow to define the least privileges required for the workflow. Based on the workflow's operations, it primarily interacts with repository contents and pull requests. Therefore, we will set `contents: read` and `pull-requests: write` permissions. This ensures the workflow has only the necessary permissions to perform its tasks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Add explicit permissions to the Azure Static Web Apps CI/CD workflow to restrict it to least privilege and satisfy code scanning requirements.

Bug Fixes:
- Fix code scanning alert by explicitly specifying workflow permissions

CI:
- Restrict workflow permissions to contents: read and pull-requests: write